### PR TITLE
Added support for missing URL names in Django 1.8-1.9.

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -159,10 +159,15 @@ class RequestModelFactory(object):
         query_params = self.query_params()
         path = self.request.path
         resolved = resolve(path)
-        namespace = resolved.namespace
-        view_name = resolved.url_name
-        if namespace:
-            view_name = namespace + ':' + view_name
+        try:
+          # view_name is set in Django >= 1.8
+          view_name = resolved.view_name
+        except AttributeError:
+          # support for Django 1.6 and 1.7 in which no view_name is set
+          view_name = resolved.url_name
+          namespace = resolved.namespace
+          if namespace:
+              view_name = namespace + ':' + view_name
         request_model = models.Request.objects.create(
             path=path,
             encoded_headers=self.encoded_headers(),


### PR DESCRIPTION
Resolves #89 by using Django's url_name when it is present.
A fallback is included for Django 1.6-1.7.