### PR TITLE
Conditional migration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
 
 script:
     - cd project
-    - echo $DJANGO
     - ./tests/test_migrations.sh
     - python manage.py test --noinput
     - cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
 script:
     - cd project
-    - python manage.py syncdb --noinput
-    - python manage.py migrate --noinput || true # Only for 1.7/1.8
+    - echo $DJANGO
+    - ./tests/test_migrations.sh
     - python manage.py test --noinput
     - cd -

--- a/project/tests/test_migrations.sh
+++ b/project/tests/test_migrations.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ev
+
+# Use migrate for Django>=1.6.0,<1.7.0
+if (pip freeze | grep Django==1.[6-7].[0-9]*)
+then
+  python django-admin.py syncdb --noinput
+fi
+
+# Use migrate for Django>=1.8.0,<1.10.0
+if (pip freeze | grep Django==1.[8-9\|10].[0-9]*)
+then
+  python manage.py migrate --noinput
+fi


### PR DESCRIPTION
Resolves #91 by running the migration tests from a separate shell script which checks the Django verson before running ``django-admin.py syncdb`` or ``manage.py migrate``.