### PR TITLE
Response bodies are now stored b64 encoded (support for binary responses).

### DIFF
--- a/silk/models.py
+++ b/silk/models.py
@@ -1,5 +1,6 @@
 from collections import Counter
 import json
+import base64
 
 from django.db import models
 from django.db.models import DateTimeField, TextField, CharField, ForeignKey, IntegerField, BooleanField, F, \
@@ -125,6 +126,10 @@ class Response(models.Model):
         else:
             raw = {}
         return CaseInsensitiveDictionary(raw)
+
+    @property
+    def raw_body_decoded(self):
+        return base64.b64decode(self.raw_body)
 
 
 # TODO rewrite docstring

--- a/silk/templates/silk/request.html
+++ b/silk/templates/silk/request.html
@@ -152,13 +152,15 @@
             {% endif %}
             {% if silk_request.response.raw_body %}
                 {% heading 'Raw Response Body' %}
-                {% if silk_request.response.raw_body|length > 1000 %}
-                    The raw response body is <b>{{ silk_request.response.raw_body|length }}</b> characters long
-                    and hence is <b>too big</b> to show here.
-                    Click <a href="{% url "silk:raw" silk_request.pk %}?typ=response&subtyp=raw">here</a> to view the raw response body.
-                {% else %}
-                    <pre>{{ silk_request.response.raw_body }}</pre>
-                {% endif %}
+                {% with raw_body=silk_request.response.raw_body_decoded %}
+                    {% if raw_body|length > 1000 %}
+                        The raw response body is <b>{{ raw_body|length }}</b> characters long
+                        and hence is <b>too big</b> to show here.
+                        Click <a href="{% url "silk:raw" silk_request.pk %}?typ=response&subtyp=raw">here</a> to view the raw response body.
+                    {% else %}
+                        <pre>{{ raw_body }}</pre>
+                    {% endif %}
+                {% endwith %}
             {% endif %}
             {% if silk_request.response.body %}
                 {% heading 'Response Body' %}

--- a/silk/views/raw.py
+++ b/silk/views/raw.py
@@ -19,7 +19,7 @@ class Raw(View):
         if typ and subtyp:
             silk_request = Request.objects.get(pk=request_id)
             if typ == 'request':
-                body = silk_request.raw_body_ if subtyp == 'raw' else silk_request.body
+                body = silk_request.raw_body if subtyp == 'raw' else silk_request.body
             elif typ == 'response':
                 Logger.debug(silk_request.response.raw_body_decoded)
                 body = silk_request.response.raw_body_decoded if subtyp == 'raw' else silk_request.response.body

--- a/silk/views/raw.py
+++ b/silk/views/raw.py
@@ -4,6 +4,8 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 from silk.auth import login_possibly_required, permissions_possibly_required
 from silk.models import Request
+import logging
+Logger = logging.getLogger('silk')
 
 
 class Raw(View):
@@ -17,9 +19,10 @@ class Raw(View):
         if typ and subtyp:
             silk_request = Request.objects.get(pk=request_id)
             if typ == 'request':
-                body = silk_request.raw_body if subtyp == 'raw' else silk_request.body
+                body = silk_request.raw_body_ if subtyp == 'raw' else silk_request.body
             elif typ == 'response':
-                body = silk_request.response.raw_body if subtyp == 'raw' else silk_request.response.body
+                Logger.debug(silk_request.response.raw_body_decoded)
+                body = silk_request.response.raw_body_decoded if subtyp == 'raw' else silk_request.response.body
             return render_to_response('silk/raw.html', {
                 'body': body
             })


### PR DESCRIPTION
removed some useless encoding/decoding of response body (why it was decoded from original charset before json dump and load??)