### PR TITLE
Fixing Depreciation, Saving and Performance Tweaks

### DIFF
--- a/project/tests/test_config_meta.py
+++ b/project/tests/test_config_meta.py
@@ -23,7 +23,7 @@ class TestConfigMeta(TestCase):
         delete_all_models(Request)
         DataCollector().configure(Request.objects.create())
         response = self._mock_response()
-        SilkyMiddleware()._process_response(response)
+        SilkyMiddleware()._process_response('', response)
         self.assertTrue(response.status_code == 200)
         objs = Request.objects.all()
         self.assertEqual(objs.count(), 1)

--- a/silk/models.py
+++ b/silk/models.py
@@ -210,7 +210,7 @@ class SQLQuery(models.Model):
         if not self.pk:
             if self.request:
                 self.request.num_sql_queries += 1
-                self.request.save()
+                self.request.save(update_fields=['num_sql_queries'])
 
         super(SQLQuery, self).save(*args, **kwargs)
 

--- a/silk/views/requests.py
+++ b/silk/views/requests.py
@@ -1,4 +1,4 @@
-from django.core.context_processors import csrf
+from django.template.context_processors import csrf
 
 from django.db.models import Sum
 from django.shortcuts import render_to_response

--- a/silk/views/summary.py
+++ b/silk/views/summary.py
@@ -1,4 +1,4 @@
-from django.core.context_processors import csrf
+from django.template.context_processors import csrf
 from django.db.models import Avg, Count, Sum, Max
 from django.shortcuts import render_to_response
 from django.utils.decorators import method_decorator


### PR DESCRIPTION
I can break this up, but simply this fixes:

- Django deprecation warnings.
- A previous commit broke sql and profile saving entirely.
- Stop attaching the profiler every run if not used.
- Better update of total queries (Though this really could be refactored into one update)