### PR TITLE
remove claim to support django 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Silk is a live profiling and inspection tool for the Django framework. Silk inte
 
 Silk has been tested with:
 
-* Django: 1.6, 1.7, 1.8, 1.9, 1.10[dev]
+* Django: 1.7, 1.8, 1.9, 1.10[dev]
 * Python: 2.7, 3.3, 3.4, 3.5
 
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Requirements
 
 Silk has been tested with:
 
--  Django: 1.6, 1.7, 1.8
+-  Django: 1.7, 1.8
 -  Python: 2.7, 3.3, 3.4
 
 Installation


### PR DESCRIPTION
it's confusing to look at master's readme claiming support and then noticing
it's not supported.