### PR TITLE
make file paths clickable that don't start with a slash

### DIFF
--- a/silk/templatetags/silk_filters.py
+++ b/silk/templatetags/silk_filters.py
@@ -26,7 +26,7 @@ def spacify(value, autoescape=None):
 
 
 def _urlify(str):
-    r = re.compile("(?P<src>/.*\.py)\", line (?P<num>[0-9]+).*")
+    r = re.compile('"(?P<src>.*\.py)", line (?P<num>[0-9]+).*')
     m = r.search(str)
     while m:
         group = m.groupdict()

--- a/silk/views/sql_detail.py
+++ b/silk/views/sql_detail.py
@@ -35,7 +35,7 @@ def _code_context(file_path, line_num):
 class SQLDetailView(View):
     def _urlify(self, str):
         files = []
-        r = re.compile("(?P<src>/.*\.py)\", line (?P<num>[0-9]+).*")
+        r = re.compile('"(?P<src>.*\.py)", line (?P<num>[0-9]+).*')
         m = r.search(str)
         n = 1
         while m:


### PR DESCRIPTION
by achoring based on the double quote enclosing the path instead of
using the forward slash.