### PR TITLE
use any readme

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE
-include README.rst
+include README*
 recursive-include silk/templates *
 recursive-include silk/static *
 recursive-include silk/code_generation/ *.py


### PR DESCRIPTION
#### What:
* Include any readme file

#### Why:
* See issue: https://github.com/django-silk/silk/issues/127
* The markdown README file is not included in the wheel, so systems without pyandoc cannot `pip install django-silk` 
