### PR TITLE
Namespaced loggers

### DIFF
--- a/silk/collector.py
+++ b/silk/collector.py
@@ -18,7 +18,7 @@ TYP_SILK_QUERIES = 'silk_queries'
 TYP_PROFILES = 'profiles'
 TYP_QUERIES = 'queries'
 
-Logger = logging.getLogger('silk')
+Logger = logging.getLogger('silk.collector')
 
 
 def raise_middleware_error():

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -15,7 +15,7 @@ from silk.profiling import dynamic
 from silk.profiling.profiler import silk_meta_profiler
 from silk.sql import execute_sql
 
-Logger = logging.getLogger('silk')
+Logger = logging.getLogger('silk.middleware')
 
 
 def silky_reverse(name, *args, **kwargs):

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -11,7 +11,7 @@ from silk import models
 from silk.collector import DataCollector
 from silk.config import SilkyConfig
 
-Logger = logging.getLogger('silk')
+Logger = logging.getLogger('silk.model_factory')
 
 content_types_json = ['application/json',
                       'application/x-javascript',

--- a/silk/profiling/dynamic.py
+++ b/silk/profiling/dynamic.py
@@ -8,7 +8,7 @@ from silk.utils import six
 
 from silk.profiling.profiler import silk_profile
 
-Logger = logging.getLogger('silk')
+Logger = logging.getLogger('silk.profiling.dynamic')
 
 
 def _get_module(module_name):

--- a/silk/profiling/profiler.py
+++ b/silk/profiling/profiler.py
@@ -12,7 +12,7 @@ from silk.collector import DataCollector
 from silk.config import SilkyConfig
 from silk.models import _time_taken
 
-Logger = logging.getLogger('silk')
+Logger = logging.getLogger('silk.profiling.profiler')
 
 
 # noinspection PyPep8Naming

--- a/silk/request_filters.py
+++ b/silk/request_filters.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from silk.profiling.dynamic import _get_module
 
 from silk.templatetags.silk_filters import _silk_date_time
-logger = logging.getLogger('silk')
+logger = logging.getLogger('silk.request_filters')
 
 
 class FilterValidationError(Exception):

--- a/silk/sql.py
+++ b/silk/sql.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from silk.collector import DataCollector
 from silk.config import SilkyConfig
 
-Logger = logging.getLogger('silk')
+Logger = logging.getLogger('silk.sql')
 
 
 def _should_wrap(sql_query):

--- a/silk/views/raw.py
+++ b/silk/views/raw.py
@@ -5,7 +5,7 @@ from django.views.generic import View
 from silk.auth import login_possibly_required, permissions_possibly_required
 from silk.models import Request
 import logging
-Logger = logging.getLogger('silk')
+Logger = logging.getLogger('silk.views.raw')
 
 
 class Raw(View):


### PR DESCRIPTION
Enables finer-grained logging configuration. If I want to suppress e.g. https://github.com/django-silk/silk/blob/6f8a5741115640dc752ef95951058b420d55dbe8/silk/profiling/profiler.py#L106 but not other warnings, with this patch I can change the logging level for `"silk.profiling.profiler" independently.