### PR TITLE
Profiler files path configurable

### DIFF
--- a/silk/config.py
+++ b/silk/config.py
@@ -26,6 +26,7 @@ class SilkyConfig(six.with_metaclass(Singleton, object)):
         'SILKY_INTERCEPT_PERCENT': 100,
         'SILKY_INTERCEPT_FUNC': None,
         'SILKY_PYTHON_PROFILER': False,
+        'SILKY_PYTHON_PROFILER_RESULT_PATH': ''
     }
 
     def _setup(self):


### PR DESCRIPTION
Hi!

This provides a new config constant to select the path in which the `prof files` should be saved (#131), It can be configured through the `SILKY_PYTHON_PROFILER_RESULT_PATH`, by default is `''`.