### PR TITLE
Django 1.10 compatibility

### DIFF
--- a/project/tests/test_lib/mock_suite.py
+++ b/project/tests/test_lib/mock_suite.py
@@ -155,7 +155,7 @@ class MockSuite(object):
         response_body = random.choice(self.response_content[response_content_type])
         models.Response.objects.create(request=request,
                                        status_code=random.choice(self.status_codes),
-                                       content_type=json.dumps({'content-type': response_content_type}),
+                                       encoded_headers=json.dumps({'content-type': response_content_type}),
                                        body=response_body)
         self.mock_sql_queries(request=request, n=num_sql_queries)
         self.mock_profiles(request, random.randint(0, 2))

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -58,9 +58,6 @@ class TestMiddleware(object):
 
 
 class SilkyMiddleware(object):
-    def __init__(self):
-        super(SilkyMiddleware, self).__init__()
-
     def _apply_dynamic_mappings(self):
         dynamic_profile_configs = config.SILKY_DYNAMIC_PROFILING
         for conf in dynamic_profile_configs:

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -15,6 +15,13 @@ from silk.profiling import dynamic
 from silk.profiling.profiler import silk_meta_profiler
 from silk.sql import execute_sql
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    # Works perfectly for everyone using MIDDLEWARE_CLASSES
+    MiddlewareMixin = object
+
+
 Logger = logging.getLogger('silk.middleware')
 
 
@@ -57,7 +64,7 @@ class TestMiddleware(object):
         return
 
 
-class SilkyMiddleware(object):
+class SilkyMiddleware(MiddlewareMixin):
     def _apply_dynamic_mappings(self):
         dynamic_profile_configs = config.SILKY_DYNAMIC_PROFILING
         for conf in dynamic_profile_configs:


### PR DESCRIPTION
Heya!

I made the SilkyMiddleware compatible with the new Django 1.10 middleware and also fixed the broken tests (typo with content_type not being a field on Response).

Thanks!
Remco