### PR TITLE
Remove trailing slashes in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,8 @@ include LICENSE
 include README*
 recursive-include silk/templates *
 recursive-include silk/static *
-recursive-include silk/code_generation/ *.py
-recursive-include silk/profiling/ *.py
-recursive-include silk/utils/ *.py
-recursive-include silk/views/ *.py
+recursive-include silk/code_generation *.py
+recursive-include silk/profiling *.py
+recursive-include silk/utils *.py
+recursive-include silk/views *.py
 recursive-include silk *.py


### PR DESCRIPTION
Trailing slashes breaks compilation on Windows. This commit removes these trailing slashes.