### PR TITLE
Operational Error When Silk Is Used On Big SQL Queries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Pillow>=3.2
 django>=1.8
 freezegun>=0.3,<0.4
 factory-boy==2.6.0
+mysqlclient==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'sqlparse',
         'Jinja2',
         'autopep8',
-        'pytz'
+        'pytz',
+        'mysqlclient'
     ]
 )

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -1,6 +1,8 @@
 import logging
 import random
 
+from MySQLdb import OperationalError
+
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.db import transaction
 
@@ -128,5 +130,12 @@ class SilkyMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         if getattr(request, 'silk_is_intercepted', False):
-            self._process_response(request, response)
+            while True:
+                try:
+                    self._process_response(request, response)
+                except (AttributeError, OperationalError):
+                    print "Trying again"
+                    self._process_response(request, response)
+                finally:
+                    break
         return response

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -134,7 +134,7 @@ class SilkyMiddleware(MiddlewareMixin):
                 try:
                     self._process_response(request, response)
                 except (AttributeError, OperationalError):
-                    print "Trying again"
+                    Logger.debug('Retrying _process_response')
                     self._process_response(request, response)
                 finally:
                     break


### PR DESCRIPTION
## What
Keep trying the `_process_response` until it works. It tends to fail with big MySQL queries.

## Why
MySQLdb specifically does not manage the connections and will error if you try to reuse a stale connection. One that has closed or expired. You need to explicitly check for this error case and handle it. This PR excepts the `OperationalError` whenever the `silk` middleware has to processs a relatively large query in it's `_process_response`.