### PR TITLE
Updates exception handling to use Django DatabaseError class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ Pillow>=3.2
 django>=1.8
 freezegun>=0.3,<0.4
 factory-boy==2.6.0
-mysqlclient==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,5 @@ setup(
         'Jinja2',
         'autopep8',
         'pytz',
-        'mysqlclient'
     ]
 )

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -1,10 +1,8 @@
 import logging
 import random
 
-from MySQLdb import OperationalError
-
 from django.core.urlresolvers import reverse, NoReverseMatch
-from django.db import transaction
+from django.db import transaction, DatabaseError
 
 from django.db.models.sql.compiler import SQLCompiler
 from django.utils import timezone
@@ -133,7 +131,7 @@ class SilkyMiddleware(MiddlewareMixin):
             while True:
                 try:
                     self._process_response(request, response)
-                except (AttributeError, OperationalError):
+                except (AttributeError, DatabaseError):
                     Logger.debug('Retrying _process_response')
                     self._process_response(request, response)
                 finally:


### PR DESCRIPTION
Addresses #142

Using Django’s DatabaseError class as the exception to catch keeps the
library and this try catch database platform agnostic. That way
developers who have a Postgres or MySQL backend should mutually benefit
from this retry.