### PR TITLE
Travis config to test on the different django database backends.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,23 @@ python:
     - "3.4"
     - "3.5"
 env:
-    - DJANGO="Django>=1.7.0,<1.8.0"
-    - DJANGO="Django>=1.8.0,<1.9.0"
-    - DJANGO="Django>=1.9.0,<1.10.0"
-    - DJANGO="Django>=1.10b1,<1.11.0"
+    # PostgreSQL
+    - DJANGO="Django>=1.7.0,<1.8.0"   DB=postgresql DB_NAME=travis_ci_test
+    - DJANGO="Django>=1.8.0,<1.9.0"   DB=postgresql DB_NAME=travis_ci_test
+    - DJANGO="Django>=1.9.0,<1.10.0"  DB=postgresql DB_NAME=travis_ci_test
+    - DJANGO="Django>=1.10b1,<1.11.0" DB=postgresql DB_NAME=travis_ci_test
+
+    # SQLite3
+    - DJANGO="Django>=1.7.0,<1.8.0"   DB=sqlite3 DB_NAME=db.sqlite3
+    - DJANGO="Django>=1.8.0,<1.9.0"   DB=sqlite3 DB_NAME=db.sqlite3
+    - DJANGO="Django>=1.9.0,<1.10.0"  DB=sqlite3 DB_NAME=db.sqlite3
+    - DJANGO="Django>=1.10b1,<1.11.0" DB=sqlite3 DB_NAME=db.sqlite3
+
+    # MySQL
+    - DJANGO="Django>=1.7.0,<1.8.0"   DB=mysql DB_NAME=mysql_db
+    - DJANGO="Django>=1.8.0,<1.9.0"   DB=mysql DB_NAME=mysql_db
+    - DJANGO="Django>=1.9.0,<1.10.0"  DB=mysql DB_NAME=mysql_db
+    - DJANGO="Django>=1.10b1,<1.11.0" DB=mysql DB_NAME=mysql_db
 
 matrix:
   allow_failures:
@@ -24,6 +37,13 @@ matrix:
 install:
     - pip install -q $DJANGO
     - pip install -r requirements.txt
+    
+    # Handle PostgreSQL
+    - if [[ "$DB" = "postgresql" ]]; then pip install psycopg2; fi
+    - if [[ "$DB" = "postgresql" ]]; then psql -c 'create database travis_ci_test;' -U postgres; fi
+
+    # Handle MySQL
+    - if [[ "$DB" = "mysql" ]]; then mysql -e 'create database mysql_db;'; fi
 
 script:
     - cd project

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
     - if [[ "$DB" = "postgresql" ]]; then psql -c 'create database travis_ci_test;' -U postgres; fi
 
     # Handle MySQL
-    - if [[ "$DB" = "mysql" ]]; then pip install mysql-python; fi
+    - if [[ "$DB" = "mysql" ]]; then pip install mysqlclient; fi
     - if [[ "$DB" = "mysql" ]]; then mysql -e 'create database mysql_db;'; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
     - if [[ "$DB" = "postgresql" ]]; then psql -c 'create database travis_ci_test;' -U postgres; fi
 
     # Handle MySQL
+    - if [[ "$DB" = "mysql" ]]; then pip install mysql-python; fi
     - if [[ "$DB" = "mysql" ]]; then mysql -e 'create database mysql_db;'; fi
 
 script:

--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -34,9 +34,13 @@ MIDDLEWARE_CLASSES = (
 
 WSGI_APPLICATION = 'wsgi.application'
 
+DB = os.environ['DB']
+if DB == 'postgres':
+    DB = 'postgresql_psycopg2'
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.' + os.environ['DB'],
+        'ENGINE': 'django.db.backends.' + DB,
         'NAME': os.environ['DB_NAME']
     }
 }

--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -34,12 +34,10 @@ MIDDLEWARE_CLASSES = (
 
 WSGI_APPLICATION = 'wsgi.application'
 
-DB_NAME = os.path.join(BASE_DIR, 'db.sqlite3')
-
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': DB_NAME
+        'ENGINE': 'django.db.backends.' + os.environ['DB'],
+        'NAME': os.environ['DB_NAME']
     }
 }
 

--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -35,7 +35,7 @@ MIDDLEWARE_CLASSES = (
 WSGI_APPLICATION = 'wsgi.application'
 
 DB = os.environ['DB']
-if DB == 'postgres':
+if DB == 'postgresql':
     DB = 'postgresql_psycopg2'
 
 DATABASES = {


### PR DESCRIPTION
Hi all, I have added some config to `.travis.yml` to allow for testing on "most" of the Django database backends. I have included PostgreSQL, MySQL and SQLite3. The only default Django backend that is missing is Oracle. This can be included however it would mean pulling in [this project](https://github.com/cbandy/travis-oracle) and also a maintainer setting up an oracle account.

The motivation for this change is issue #142 and to allow for earlier detection so that a broken release doesn't make it to PyPi.

As you can [see on Travis](https://travis-ci.org/mattjegan/silk/builds/165481576) it works well.