### PR TITLE
Allow using Django 1.10 MIDDLEWARE setting instead of MIDDLEWARE_CLASSES

### DIFF
--- a/silk/profiling/profiler.py
+++ b/silk/profiling/profiler.py
@@ -3,6 +3,7 @@ import logging
 import time
 import traceback
 
+import django
 from django.conf import settings
 from django.utils import timezone
 
@@ -126,6 +127,8 @@ class silk_profile(object):
     def _silk_installed(self):
         app_installed = 'silk' in settings.INSTALLED_APPS
         middleware_installed = 'silk.middleware.SilkyMiddleware' in settings.MIDDLEWARE_CLASSES
+        if django.VERSION[:2] >= (1, 10):
+            middleware_installed = middleware_installed or 'silk.middleware.SilkyMiddleware' in settings.MIDDLEWARE
         return app_installed and middleware_installed
 
     def _should_profile(self):


### PR DESCRIPTION
Hello!
When using MIDDLEWARE setting from Django 1.10 (instead of MIDDLEWARE_CLASSES, like [README](https://github.com/django-silk/silk/blob/85af6e2d25cf1e1be44d5de142fdfa8ec11754e5/README.md) suggests), silk keeps complaining that
```
Cannot execute silk_profile as silk is not installed correctly.
```
This PR fixes that.