### PR TITLE
Update middleware setting for Django >= 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ pip install django-silk
 In `settings.py` add the following:
 
 ```python
+# Django >= 1.10
+MIDDLEWARE = [
+    ...
+    'silk.middleware.SilkyMiddleware',
+    ...
+]
+
+# Django <= 1.9
 MIDDLEWARE_CLASSES = (
     ...
     'silk.middleware.SilkyMiddleware',


### PR DESCRIPTION
Django >= 1.10 : `MIDDLEWARE` is list type.
Django < 1.9 : `MIDDLEWARE_CLASSES` is tuple type.

Details here : https://docs.djangoproject.com/en/1.10/releases/1.10/#new-style-middleware

Therefore,

~~~~
MIDDLEWARE_CLASSES = (
    ...
    'silk.middleware.SilkyMiddleware',
    ...
)
~~~~

would be

~~~~
MIDDLEWARE = [
    ...
    'silk.middleware.SilkyMiddleware',
    ...
]
~~~~
