### PR TITLE
Fixes #161

### DIFF
--- a/silk/collector.py
+++ b/silk/collector.py
@@ -133,11 +133,11 @@ class DataCollector(with_metaclass(Singleton, object)):
             self.request.save()
 
     def stop_python_profiler(self):
-        if hasattr(self.local, 'pythonprofiler'):
+        if getattr(self.local, 'pythonprofiler', None):
             self.local.pythonprofiler.disable()
 
     def finalise(self):
-        if hasattr(self.local, 'pythonprofiler'):
+        if getattr(self.local, 'pythonprofiler', None):
             s = StringIO()
             ps = pstats.Stats(self.local.pythonprofiler, stream=s).sort_stats('cumulative')
             ps.print_stats()


### PR DESCRIPTION
The middleware wasn't storing anything because when tried to disable python profiler and it doesn't exists (initialized with None) raise a ValueError, so that the middleware stops at this point and don't register anything.