### PR TITLE
Add text-align property to pyprofile class for readability

### DIFF
--- a/silk/templates/silk/profile_detail.html
+++ b/silk/templates/silk/profile_detail.html
@@ -21,6 +21,10 @@
 
         }
 
+        .pyprofile {
+            text-align: left;
+        }
+
         a {
             color: #45ADA8;
         }


### PR DESCRIPTION
Hi, 

This PR adds the `text-align: left` to the pyprofile class in the profiling view. 

![image](https://cloud.githubusercontent.com/assets/3045891/25868498/b87a6cdc-34b1-11e7-8e66-ae0a4779c8cd.png)

As shown in the above screenshot, without a text align the output is difficult to read with longer function names. 

![image](https://cloud.githubusercontent.com/assets/3045891/25868523/d06294be-34b1-11e7-97bf-d3186ba6ea51.png)

With the `text-align` added, it is much more readable. 

Thank you for the consideration! This is an incredibly useful package for us. 